### PR TITLE
feat: use fromWebAuthn adapter for UserOp signing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "safe-candide-passkeys",
       "version": "0.0.0",
       "dependencies": {
-        "abstractionkit": "0.3.2",
+        "abstractionkit": "file:../abstractionkit",
         "ox": "^0.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -22,11 +22,22 @@
         "vite": "^5.0.12"
       }
     },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
+    "../abstractionkit": {
+      "version": "0.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "ethers": "^6.13.2"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.12",
+        "dotenv": "^16.4.5",
+        "jest": "^29.7.0",
+        "tsdown": "^0.21.6",
+        "typescript": "^5.1.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -426,30 +437,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1160,7 +1147,10 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1229,22 +1219,8 @@
       }
     },
     "node_modules/abstractionkit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/abstractionkit/-/abstractionkit-0.3.2.tgz",
-      "integrity": "sha512-Ay2Sxd7bpX/hzjV5QhrUjxppLFombSPjamqxuRwwE7WMMGAJLhmWI88FCS5cHYSsLbXxtemsxr9DWSReegbf/A==",
-      "license": "MIT",
-      "dependencies": {
-        "ethers": "^6.13.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
+      "resolved": "../abstractionkit",
+      "link": true
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1290,34 +1266,6 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
-      }
-    },
-    "node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -1610,12 +1558,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1634,7 +1576,10 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -1692,27 +1637,6 @@
           "optional": true
         },
         "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "abstractionkit": "0.3.2",
+    "abstractionkit": "file:../abstractionkit",
     "ox": "^0.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import safeLogo from "/safe-logo-white.svg";
 import candideLogo from "/candide-atelier-logo.svg";
-import { createPasskey, toLocalStorageFormat } from "./logic/passkeys.ts";
+import { createPasskey, fromLocalStorageFormat, toLocalStorageFormat } from "./logic/passkeys.ts";
 import type { PasskeyLocalStorageFormat } from "./logic/passkeys.ts";
 import "./App.css";
 import { useLocalStorageState } from "./hooks/useLocalStorageState.ts";
@@ -22,9 +22,14 @@ function App() {
 	// backend you control, OR pack the compressed pubkey into the WebAuthn
 	// userHandle so it's returned on every `navigator.credentials.get()`.
 	// Don't ship this pattern as-is.
-	const [passkey, setPasskey] = useLocalStorageState<
+	const [rawPasskey, setPasskey] = useLocalStorageState<
 		PasskeyLocalStorageFormat | undefined
 	>(PASSKEY_LOCALSTORAGE_KEY, undefined);
+	// `useLocalStorageState` reads with plain JSON.parse, but `storage.ts`
+	// writes bigints as hex strings. Rehydrate the coords to bigint here so
+	// downstream callers (fromWebAuthn, createAccountAddress) see the
+	// declared type.
+	const passkey = rawPasskey ? fromLocalStorageFormat(rawPasskey) : rawPasskey;
 	const [error, setError] = useState<string>();
 
 	const handleCreatePasskeyClick = async () => {

--- a/src/logic/passkeys.ts
+++ b/src/logic/passkeys.ts
@@ -69,8 +69,31 @@ function toLocalStorageFormat(passkey: P256Credential): PasskeyLocalStorageForma
   }
 }
 
+/**
+ * Re-hydrate a passkey pulled from localStorage.
+ *
+ * `storage.ts` writes bigints as hex strings (`"0x…"`) with a
+ * JSON.stringify replacer, but `useLocalStorageState` reads with plain
+ * `JSON.parse` — no inverse reviver — so after a round-trip
+ * `pubkeyCoordinates.{x,y}` are strings, not bigints. Callers that pass
+ * the coords to APIs with strict bigint types (e.g. `fromWebAuthn`) must
+ * coerce before use. Idempotent — safe to call on freshly-minted passkeys
+ * whose coords are already bigints.
+ */
+function fromLocalStorageFormat(passkey: PasskeyLocalStorageFormat): PasskeyLocalStorageFormat {
+  const { x, y } = passkey.pubkeyCoordinates
+  return {
+    id: passkey.id,
+    pubkeyCoordinates: {
+      x: typeof x === 'bigint' ? x : BigInt(x),
+      y: typeof y === 'bigint' ? y : BigInt(y),
+    },
+  }
+}
+
 
 export {
 	createPasskey,
 	toLocalStorageFormat,
+	fromLocalStorageFormat,
 };

--- a/src/logic/passkeys.ts
+++ b/src/logic/passkeys.ts
@@ -2,6 +2,7 @@ import {
   createCredential,
   type P256Credential,
 } from 'ox/WebAuthnP256'
+import { pubkeyCoordinatesFromJson } from 'abstractionkit'
 
 
 /**
@@ -75,19 +76,18 @@ function toLocalStorageFormat(passkey: P256Credential): PasskeyLocalStorageForma
  * `storage.ts` writes bigints as hex strings (`"0x…"`) with a
  * JSON.stringify replacer, but `useLocalStorageState` reads with plain
  * `JSON.parse` — no inverse reviver — so after a round-trip
- * `pubkeyCoordinates.{x,y}` are strings, not bigints. Callers that pass
- * the coords to APIs with strict bigint types (e.g. `fromWebAuthn`) must
- * coerce before use. Idempotent — safe to call on freshly-minted passkeys
- * whose coords are already bigints.
+ * `pubkeyCoordinates.{x,y}` are strings, not bigints. Idempotent — safe
+ * to call on freshly-minted passkeys whose coords are already bigints.
+ *
+ * Delegates to `abstractionkit.pubkeyCoordinatesFromJson` which accepts
+ * either a JSON string or a pre-parsed `{ x, y }` object with mixed
+ * bigint / hex-string / decimal-string values and produces canonical
+ * `{ x: bigint, y: bigint }`.
  */
 function fromLocalStorageFormat(passkey: PasskeyLocalStorageFormat): PasskeyLocalStorageFormat {
-  const { x, y } = passkey.pubkeyCoordinates
   return {
     id: passkey.id,
-    pubkeyCoordinates: {
-      x: typeof x === 'bigint' ? x : BigInt(x),
-      y: typeof y === 'bigint' ? y : BigInt(y),
-    },
+    pubkeyCoordinates: pubkeyCoordinatesFromJson(passkey.pubkeyCoordinates),
   }
 }
 

--- a/src/logic/userOp.ts
+++ b/src/logic/userOp.ts
@@ -1,11 +1,6 @@
-import { sign } from 'ox/WebAuthnP256';
-import type { Hex as OxHex } from 'ox/Hex';
-import { Bytes, Hex } from 'ox';
-import { SafeAccountV0_3_0 as SafeAccount } from 'abstractionkit';
+import { SafeAccountV0_3_0 as SafeAccount, fromWebAuthn } from 'abstractionkit';
 import type {
   SendUseroperationResponse,
-  SignerSignaturePair,
-  WebauthnSignatureData,
   UserOperationV7,
 } from 'abstractionkit';
 
@@ -13,16 +8,18 @@ import type { PasskeyLocalStorageFormat } from './passkeys';
 
 /**
  * Signs a SafeAccount UserOperation with a WebAuthn passkey and sends it to
- * the bundler.
+ * the bundler, using abstractionkit's `fromWebAuthn` adapter.
  *
- * Workflow:
- * 1. Compute the EIP-712 hash of the UserOperation.
- * 2. Sign the hash via WebAuthn (single biometric prompt).
- * 3. Extract the non-challenge `clientDataJSON` fields by parsing, not regex,
- *    so authenticators free to add fields (e.g. Safari's `crossOrigin`) don't
- *    break signing.
- * 4. Assemble the Safe-format WebAuthn signature.
- * 5. Attach to the UserOperation and dispatch to the bundler.
+ * The adapter collapses the previous manual pipeline — parsing
+ * `clientDataJSON`, assembling `WebauthnSignatureData`, calling
+ * `createWebAuthnSignature`, wrapping a `SignerSignaturePair`, and calling
+ * `formatSignaturesToUseroperationSignature` — into a single call to
+ * `signUserOperationWithSigners`. The adapter's default `signFn` invokes
+ * `navigator.credentials.get(...)` with the right
+ * `publicKey.allowCredentials`, so there's no `ox` / `@simplewebauthn`
+ * dependency on the signing path. `createPasskey` in `./passkeys.ts` still
+ * uses `ox/WebAuthnP256` for registration, which the adapter doesn't
+ * cover.
  *
  * @param smartAccount - Initialized SafeAccount instance (the sender).
  * @param userOp       - The unsigned UserOperationV7.
@@ -37,43 +34,17 @@ async function signAndSendUserOp(
   chainId: bigint,
   bundlerUrl: string,
 ): Promise<SendUseroperationResponse> {
-  // 1. EIP-712 hash of the UserOperation
-  const safeOpHash = SafeAccount.getUserOperationEip712Hash(userOp, chainId);
-
-  // 2. Sign via WebAuthn
-  const { metadata, signature } = await sign({
-    challenge: safeOpHash as OxHex,
-    credentialId: passkey.id as OxHex,
-  });
-
-  // 3. Re-serialize every clientDataJSON field except `type` and `challenge`.
-  // Robust to authenticators adding fields or reordering keys.
-  const clientData = JSON.parse(metadata.clientDataJSON);
-  const { type: _type, challenge: _challenge, ...rest } = clientData;
-  const fields = Object.entries(rest)
-    .map(([key, value]) => `"${key}":${JSON.stringify(value)}`)
-    .join(',');
-
-  // 4. Assemble the Safe-format WebAuthn signature
-  const webauthnSignatureData: WebauthnSignatureData = {
-    authenticatorData: Bytes.fromHex(metadata.authenticatorData).buffer as ArrayBuffer,
-    clientDataFields: Hex.fromString(fields),
-    rs: [signature.r, signature.s],
-  };
-
-  const webauthnSignature = SafeAccount.createWebAuthnSignature(webauthnSignatureData);
-
-  const signerSignaturePair: SignerSignaturePair = {
-    signer: passkey.pubkeyCoordinates,
-    signature: webauthnSignature,
-  };
-
-  userOp.signature = SafeAccount.formatSignaturesToUseroperationSignature(
-    [signerSignaturePair],
-    { isInit: userOp.nonce === 0n },
+  userOp.signature = await smartAccount.signUserOperationWithSigners(
+    userOp,
+    [
+      fromWebAuthn({
+        credentialId: passkey.id,
+        pubkey: passkey.pubkeyCoordinates,
+      }),
+    ],
+    chainId,
   );
 
-  // 5. Send
   return smartAccount.sendUserOperation(userOp, bundlerUrl);
 }
 


### PR DESCRIPTION
## Summary

Collapse the manual WebAuthn signing pipeline in `signAndSendUserOp` into a single `signUserOperationWithSigners(op, [fromWebAuthn(...)], chainId)` call, using the adapter landing in [candidelabs/abstractionkit#136](https://github.com/candidelabs/abstractionkit/pull/136).

- Drops 25+ lines of manual `clientDataJSON` parsing, `WebauthnSignatureData` assembly, `createWebAuthnSignature` + `SignerSignaturePair` + `formatSignaturesToUseroperationSignature` plumbing from `src/logic/userOp.ts`.
- Removes the `ox/WebAuthnP256.sign` import on the signing path (registration still uses `ox.createCredential`).
- Adds `fromLocalStorageFormat` in `src/logic/passkeys.ts` delegating to `abstractionkit.pubkeyCoordinatesFromJson` — coords are bigints again at the boundary, not after the whole app has been working with silent strings.

## Why draft

`package.json` currently pins `\"abstractionkit\": \"file:../abstractionkit\"` so testing against the local build works. Before merge this needs to be bumped to a published semver (e.g. `0.3.3` / `0.4.0`) once candidelabs/abstractionkit#136 lands and releases.

## Test plan

- [x] Local: `npm run build` clean, `npm run dev` serves, passkey register + Safe mint end-to-end
- [ ] Against released abstractionkit semver (pending #136 release)